### PR TITLE
Repo with a growing number of SPARQL queries against Wikidata

### DIFF
--- a/assets/EXTRAS_GITHUB_REPOSITORIES.txt
+++ b/assets/EXTRAS_GITHUB_REPOSITORIES.txt
@@ -60,3 +60,4 @@ NCATS-Gamma/omnicorp
 ramaschittella/INK-Browser
 IGN-CNIG/btn100
 egonw/SARS-CoV-2-Queries
+fnielsen/scholia


### PR DESCRIPTION
Consider this one carefully. It has a growing number of `.sparql` files, but these are templates and have `{{ q }}` content in them, reflecting the QID identifier in Wikidata of some entry for which that query is run. So, using these directly in YasGUI, the template need filling out. But not every SPARQL query will return something for, for example, Q5. But all file names start with the aspect, and we have example QIDs for each aspect.

@vemonet, if you reply below how SPARQL queries are being indexed, I can give more guidance on how we could index these SPARQL templates.